### PR TITLE
Expose WavFormatConfig as a public API

### DIFF
--- a/crates/oximedia-container/src/mux/wav/mod.rs
+++ b/crates/oximedia-container/src/mux/wav/mod.rs
@@ -32,4 +32,5 @@
 
 mod writer;
 
+pub use writer::WavFormatConfig;
 pub use writer::WavMuxer;


### PR DESCRIPTION
## Description
WavMuxer has a public API that takes WavFormatConfig but this struct isn't pub because `mod writer`. Alternatively could make it `pub mod writer` but I figured I'd stick to the existing pattern.

## Motivation
I want to encode Wav float but can't.

Fixes #7

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## Changes Made

Make WavFormatConfig a publicly exported type.

## Testing

N/A

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Benchmarks added/updated
- [ ] Fuzz targets added/updated
- [ ] Manual testing performed

### Test Evidence

<!-- Paste relevant test output, screenshots, or other evidence -->

```
# cargo test output or other test results
```

## Performance Impact

<!-- If this change affects performance, provide benchmarks -->

- [X] No performance impact
- [ ] Performance improvement (provide benchmarks below)
- [ ] Performance regression (justified because...):

### Benchmark Results

<!-- If applicable, paste benchmark comparison -->

```
# Before:
# After:
```

## Checklist

<!-- Mark completed items with an 'x' -->

### Code Quality

- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` and `cargo clippy`
- [ ] I have addressed all compiler warnings
- [ ] My code compiles without errors on Rust stable, beta, and nightly
- [ ] I have added appropriate error handling

### Documentation

- [ ] I have updated documentation comments (rustdoc)
- [ ] I have updated the relevant README.md files (if needed)
- [ ] I have added/updated examples (if applicable)
- [ ] Public APIs have comprehensive documentation

### Testing

- [ ] I have added tests that prove my fix/feature works
- [ ] All existing tests pass locally with my changes
- [ ] I have tested on multiple platforms (if applicable)
- [ ] I have verified no memory leaks or unsafe behavior

### Patent/Legal Compliance

- [ ] This change uses only patent-free technologies
- [X] I have not introduced any code from restrictively licensed sources
- [X] I have the right to contribute this code under the Apache-2.0 license

### Breaking Changes

<!-- If this is a breaking change, describe the migration path -->

- [ ] This PR includes breaking changes
- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have documented the migration path

### Dependencies

- [x] I have not added new dependencies (or have justified why they're needed)
- [ ] All new dependencies are compatible with Apache-2.0
- [ ] Dependencies are necessary and well-maintained

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings demonstrating the changes -->

## Additional Notes

<!-- Any other information that reviewers should know -->

## Reviewer Checklist

<!-- For maintainers reviewing this PR -->

- [ ] Code review completed
- [ ] Tests are comprehensive and pass
- [ ] Documentation is adequate
- [ ] No licensing or patent concerns
- [ ] CI/CD pipeline passes
- [ ] Benchmarks show acceptable performance
- [ ] Breaking changes are properly documented

---

**Thank you for contributing to OxiMedia!**
