### PR TITLE
Add ProRes 422 decoder

### DIFF
--- a/crates/oximedia-codec/src/lib.rs
+++ b/crates/oximedia-codec/src/lib.rs
@@ -288,6 +288,7 @@ pub mod packet_queue;
 pub mod packet_splitter;
 pub mod picture_timing;
 pub mod profile_level;
+pub mod prores;
 pub mod psycho_visual;
 pub mod quality_metrics;
 pub mod rate_control;


### PR DESCRIPTION
## Description

Completes Phase 2 of ProRes 422 decoder support — the slice-level decode pipeline that turns compressed ProRes plane bytes into 10-bit YUV422 sample buffers. Replaces the `NotImplemented` stub that Phase 1 (in `feat/prores-422-parser`) explicitly left as the extension point.

**Module:** `oximedia_codec::prores`

### What the pipeline does

```text
compressed bytes
      │
      ▼  [entropy decode]
   64 quantized integers in scan order
      │
      ▼  [inverse zigzag]
   64 quantized integers in raster (8×8) order
      │
      ▼  [dequantize × matrix × qscale]
   64 dequantized DCT coefficients
      │
      ▼  [2-D 8×8 inverse DCT]
   64 signed spatial samples
      │
      ▼  [+512, clip to [0, 1023]]
   64 unsigned 10-bit Y/Cb/Cr samples
      │
      ▼  [blit to destination plane]
   pixels in your output buffer
```

### New modules

| File | Role |
|---|---|
| [`prores/zigzag.rs`](crates/oximedia-codec/src/prores/zigzag.rs) | Progressive + alternate inverse zigzag scan tables (RDD 36 §6.5.7 Table 11). |
| [`prores/dequant.rs`](crates/oximedia-codec/src/prores/dequant.rs) | `coeff = quantized × matrix × qscale`. |
| [`prores/idct.rs`](crates/oximedia-codec/src/prores/idct.rs) | Separable 2-D 8×8 inverse DCT with Q15 fixed-point cosine constants. Row pass + column pass. Includes 10-bit output finalisation (center around 512, clip to `[0, 1023]`). |
| [`prores/entropy.rs`](crates/oximedia-codec/src/prores/entropy.rs) | Golomb-Rice codeword decoder + adaptive-K tables for DC and AC contexts. `decode_block` decodes one 8×8 block's worth of coefficients: DC differential coding + AC run/level loop with per-symbol K adaptation. |
| [`prores/decode.rs`](crates/oximedia-codec/src/prores/decode.rs) (rewrite) | Replaces the Phase 1 `NotImplemented` stub. `decode_slice_to_yuv422` calls `decode_plane` for Y / Cb / Cr; each `decode_plane` loops macroblocks → blocks → full pipeline (entropy → inverse zigzag → dequant → IDCT → finalise → blit). |

### New documentation

[`docs/prores_decoder.md`](docs/prores_decoder.md) — 790-line guided walk-through of the decoder for a contributor new to codecs. Byte-layout diagrams for every header, worked numerical examples for entropy decoding and the IDCT (full DC-only trace from 1000 → 707 → 500 through both IDCT passes), cross-references to every implementation function. Section-by-section reading order at the end.

## Motivation

ProRes is the highest-value pure-Rust codec gap that's *closeable* without patent exposure on the implementation. Unlike H.264 / HEVC (multi-quarter projects), ProRes is intra-only, well-documented in SMPTE RDD 36-2015, and tractable — every video editor and broadcast pipeline in the world touches ProRes daily.

Phase 1 (parser) landed in `feat/prores-422-parser`. This PR is Phase 2 — the actual decode pipeline. Together they form a complete logical ProRes 422 decoder, gated only on real-stream conformance validation (Phase 3).

Fixes: no tracking issue — feature work.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update *(this PR includes a substantial onboarding doc, but it's a companion to the feature work, not the primary deliverable)*
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## Changes Made

- 4 new modules: `zigzag.rs`, `dequant.rs`, `idct.rs`, `entropy.rs` under `crates/oximedia-codec/src/prores/`.
- 1 rewritten module: `prores/decode.rs` — the Phase-1 `NotImplemented` stub is gone, replaced with the full pipeline.
- `prores/mod.rs` gains the new module declarations + re-exports for the public API.
- New doc: `docs/prores_decoder.md` (19 sections, ~790 lines).
- No existing API is modified or removed. Strictly additive.

## Testing

### Test Plan

- [x] Unit tests added/updated *(32 new in this PR; 66 total in `prores`)*
- [ ] Integration tests added/updated *(deferred to Phase 3 — see "what's NOT validated" below)*
- [ ] Benchmarks added/updated *(parser-and-decoder hot paths will benefit from SIMD; benchmarks land with the SIMD pass)*
- [ ] Fuzz targets added/updated *(natural follow-up against malformed entropy streams)*
- [x] Manual testing performed

### Test Evidence

Locally on macOS aarch64:

```
$ cargo test -p oximedia-codec --lib prores
running 66 tests
test prores::bitreader::tests::align_to_byte_advances_to_boundary ... ok
test prores::bitreader::tests::count_leading_ones_counts_unary_prefix ... ok
… (66 tests)
test result: ok. 66 passed; 0 failed; 0 ignored

$ cargo build -p oximedia-codec 2>&1 | grep -E "warning|error"   # silent
$ cargo clippy -p oximedia-codec --all-targets --no-deps 2>&1 | grep -E "^(warning|error)"   # silent
$ cargo build   # full workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

Tests cover every module structurally:

- **Zigzag:** permutation property, round-trip identity, DC at scan-index 0, highest-frequency at scan-index 63.
- **IDCT:** zero-in-zero-out, DC-only produces uniform spatial block, finalise centers at 512 and clips at 10-bit range, cosine periodicity.
- **Dequant:** sign preservation, per-position matrix application, scalar inversion round-trip.
- **Entropy:** hand-traced bit patterns decode correctly for K = 0, 2, 3; signed magnitudes with positive and negative sign bits; K-adaptation tables saturate at 7; malformed input is rejected with `MalformedCodeword` rather than panicking.
- **Decode:** zero-input produces midgrey frame, DC-only produces uniform-above-midgrey block, `destination-too-small` returns a structured error, `block_offset()` arithmetic for luma 2×2 and chroma vertical layouts.

### What's NOT validated

**Real-stream bit-exact conformance against an Apple-encoded ProRes file.**

Every algorithm here matches the spec and the reference open-source decoder, every synthetic test passes, but no one has dropped a real `.mov` ProRes asset into a fixture corpus and per-pixel-compared the output against a reference decoder.

If real-stream decode produces wrong pixels, the likely culprits (in descending probability):

1. **AC end-of-block detection.** This decoder terminates the AC run/level loop on `pos >= 64`. ProRes may use specific end-of-block signalling we don't catch.
2. **K-adaptation tables.** The tables here match the open-source reference, but ProRes profiles (Proxy vs HQ) may use subtly different tables that haven't surfaced in synthetic tests.
3. **IDCT scaling constants.** The Q15 formulation is *morally* equivalent to RDD 36's, but spec-bit-exact reconstruction may require the exact integer constants from RDD 36 §6.5.7 — a Phase-3 sweep would compare per-block IDCT output against the spec's reference vectors.

This is what Phase 3 (fixture corpus + conformance harness) addresses. **Reviewers should be aware that landing this PR ships a decoder whose pipeline is correct by construction but is not yet bit-compared to ground truth.**

## Performance Impact

- [x] No performance impact *(this is the first decoder for a codec the project didn't decode before; no existing code path is changed, no benchmark regression possible)*
- [ ] Performance improvement (provide benchmarks below)
- [ ] Performance regression (justified because...):

Forward-looking note: a 1080p30 ProRes 422 frame requires ~65k 8×8 IDCTs per frame, ~2M IDCTs/sec at 30 fps. The current scalar implementation is correct but unoptimised. SIMD acceleration of `idct_1d` is a natural follow-up — expected 3–5× speedup with NEON on aarch64 / AVX2 on x86-64.

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` and `cargo clippy`
- [x] I have addressed all compiler warnings *(zero on `cargo build` and `cargo clippy --all-targets --no-deps`)*
- [ ] My code compiles without errors on Rust stable, beta, and nightly *(verified locally on stable; CI will exercise the others)*
- [x] I have added appropriate error handling *(structured `EntropyError`, `DecodeError`, `BitReaderError` enums; no `unwrap`/`expect` in non-test code)*

### Documentation

- [x] I have updated documentation comments (rustdoc) *(every public type and function has a docstring; module-level docs explain the spec section reference and the algorithm)*
- [ ] I have updated the relevant README.md files
- [ ] I have added/updated examples *(deferred until Phase 3 wires `decode_slice_to_yuv422` into a usable end-to-end flow with sample input)*
- [x] Public APIs have comprehensive documentation *(supplemented by [docs/prores_decoder.md](docs/prores_decoder.md) — 790-line decoder walk-through with worked examples)*

### Testing

- [x] I have added tests that prove my fix/feature works *(32 new unit tests, 66 total; every algorithmic branch covered)*
- [x] All existing tests pass locally with my changes *(verified — no regressions in `oximedia-codec` or any other crate)*
- [ ] I have tested on multiple platforms *(macOS aarch64 only locally; the code is pure scalar Rust with no platform-conditional logic, so CI on Linux/Windows should be uneventful)*
- [x] I have verified no memory leaks or unsafe behavior *(no `unsafe` blocks anywhere in the new code)*

### Patent/Legal Compliance

- [ ] **Same complicated story as Phase 1.** Apple holds patents on ProRes encoding. Decoder implementations have been treated as industry-tolerated for over a decade (FFmpeg has shipped a ProRes decoder since 2010 without consequence; the bitstream syntax this PR implements is publicly published in SMPTE RDD 36-2015). However, this is *not* "patent-free" in the strict sense AV1 or Opus are. Reviewers should make their own call on whether this fits the workspace's codec policy.
- [x] I have not introduced any code from restrictively licensed sources *(written from the SMPTE spec and from a reading of the open-source reference decoder; no third-party source vendored)*
- [x] I have the right to contribute this code under the Apache-2.0 license

### Breaking Changes

- [ ] This PR includes breaking changes
- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have documented the migration path

*Strictly additive. The Phase-1 public API surface is unchanged; the only signature whose behaviour changes is `decode_slice_to_yuv422`, which previously returned `Err(DecodeError::NotImplemented)` and now returns either `Ok(())` after writing into the destination buffers or a structured error.*

### Dependencies

- [x] I have not added new dependencies *(uses only `thiserror` which is already a workspace dependency)*
- [x] All new dependencies are compatible with Apache-2.0
- [x] Dependencies are necessary and well-maintained

## Additional Notes

**Stacked PR.** This branch builds on `feat/prores-422-parser` (Phase 1). The diff against `master` will include both PRs' commits. Best to land `feat/prores-422-parser` first; once that merges, this branch's diff becomes just the two Phase-2-and-doc commits.

**Reviewer hint.** The most consequential file is [`prores/entropy.rs`](crates/oximedia-codec/src/prores/entropy.rs) — that's where the spec interpretation is densest (Golomb-Rice + adaptive K + DC differential + AC run/level loop). The IDCT in [`prores/idct.rs`](crates/oximedia-codec/src/prores/idct.rs) uses a textbook-standard formulation that matches every other JPEG/MPEG/ProRes decoder. The 4 supporting files (`zigzag`, `dequant`, plus the unchanged Phase-1 files `frame`, `picture`, `quant`, `bitreader`) are mechanical translations of the spec — short and individually obvious.

**Reading suggestion.** Skim [`docs/prores_decoder.md`](docs/prores_decoder.md) first (especially §9 on Golomb-Rice and §13 on the IDCT). Then read the code with the doc open side-by-side — every section cross-references the exact function it describes.

**Out of scope — explicit follow-ups:**

- **Phase 3 — real-stream conformance.** Fixture corpus + per-pixel diff against a reference decoder. The validation gate before wiring into `VideoDecoder`.
- ProRes **4444 alpha-plane** decode (parser already recognises it; pipeline doesn't decode it).
- **Alternate (interlaced) zigzag** wired into `decode_slice_to_yuv422` (table exists; the slice decoder currently hardcodes progressive).
- **Multi-slice picture orchestration** (this function decodes one slice; a frame-level driver iterates the slice list).
- Integration with `oximedia_codec::VideoDecoder` trait + `CodecId::ProRes422` registry variant — gated on Phase 3 because landing the wiring before bit-exact conformance would silently produce wrong pixels.
- **SIMD acceleration** of `idct_1d` and the entropy decoder hot path.
- **Fuzz target** against malformed entropy streams.
